### PR TITLE
0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gray_matter"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["yuchanns <airamusume@gmail.com>", "Knut Magnus Aasrud <km@aasrud.com>"]
 edition = "2018"
 license = "MIT"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.1
+
+### Enhancements
+
+- gray-matter is now more strict with delimiters and whitespace on the same line. Previously, whitespace was allowed both before and after the delimiter. Now, you can only have whitespace after the delimiter.
+- gray-matter is also less strict with the first delimiter. It does not allow whitespace at the start of the line, but does so at the end (which it did not previously).
+
+### Bug fixes
+
+- Fixed a panic that was thrown when two delimiters directly followed eachother.
+
 ## 0.2.0
 
 ### Major changes

--- a/src/matter.rs
+++ b/src/matter.rs
@@ -72,8 +72,10 @@ impl<T: Engine> Matter<T> {
         // If first line starts with a delimiter followed by newline, we are looking at front
         // matter. Else, we might be looking at an excerpt.
         let (mut looking_at, lines) = match input.split_once('\n') {
-            Some((first_line, rest)) if first_line.trim_end() == self.delimiter => (Part::Matter, rest.lines()),
-            _ => (Part::MaybeExcerpt, input.lines())
+            Some((first_line, rest)) if first_line.trim_end() == self.delimiter => {
+                (Part::Matter, rest.lines())
+            }
+            _ => (Part::MaybeExcerpt, input.lines()),
         };
 
         let mut acc = String::new();

--- a/src/matter.rs
+++ b/src/matter.rs
@@ -97,7 +97,7 @@ impl<T: Engine> Matter<T> {
                             .replace_all(&acc, "")
                             .trim()
                             .strip_suffix(&self.delimiter)
-                            .unwrap()
+                            .expect("Could not strip front matter delimiter. You should not be able to get this message")
                             .trim_matches('\n')
                             .to_string();
 
@@ -115,10 +115,8 @@ impl<T: Engine> Matter<T> {
                     if line.trim() == excerpt_delimiter {
                         parsed_entity.excerpt = Some(
                             acc.trim()
-                                .strip_prefix(&self.delimiter)
-                                .unwrap_or(&acc)
                                 .strip_suffix(&excerpt_delimiter)
-                                .unwrap()
+                                .expect("Could not strip excerpt delimiter. You should not be able to get this message")
                                 .trim_matches('\n')
                                 .to_string(),
                         );


### PR DESCRIPTION
- gray-matter is now more strict with delimiters and whitespace on the same line. Previously, whitespace was allowed both before and after the delimiter. Now, you can only have whitespace after the delimiter.
- gray-matter is also less strict with the first delimiter. It does not allow whitespace at the start of the line, but does so at the end (which it did not previously).
- Fixed a panic that was thrown when two delimiters directly followed eachother #6.