### PR TITLE
Allow excerpt delimiter to be on the same line

### DIFF
--- a/src/matter.rs
+++ b/src/matter.rs
@@ -105,7 +105,7 @@ impl<T: Engine> Matter<T> {
                 }
 
                 Part::MaybeExcerpt => {
-                    if line.trim_end() == excerpt_delimiter {
+                    if line.trim_end().ends_with(&excerpt_delimiter) {
                         parsed_entity.excerpt = Some(
                             acc.trim()
                                 .strip_suffix(&excerpt_delimiter)
@@ -263,6 +263,26 @@ mod tests {
         assert_eq!(
             true,
             result.content == "foo\nbar\nbaz\n<!-- endexcerpt -->\ncontent".to_string(),
+            "should use a custom separator"
+        );
+        assert_eq!(
+            result.excerpt.unwrap(),
+            "foo\nbar\nbaz",
+            "should get excerpt as \"foo\nbar\nbaz\""
+        );
+
+        // Check that the endexcerpt delimiter can be on the same line
+        let result: ParsedEntityStruct<FrontMatter> = matter
+            .parse_with_struct("---\nabc: xyz\n---\nfoo\nbar\nbaz<!-- endexcerpt -->\ncontent")
+            .unwrap();
+        assert_eq!(
+            true,
+            result.data.abc == "xyz".to_string(),
+            "should get front matter xyz as value of abc"
+        );
+        assert_eq!(
+            true,
+            result.content == "foo\nbar\nbaz<!-- endexcerpt -->\ncontent".to_string(),
             "should use a custom separator"
         );
         assert_eq!(


### PR DESCRIPTION
## Description

Currently, the `excerpt_delimiter` needs to be on its own line otherwise the excerpt will not be taken into account.

The code below works as expected:
```
---
abc: xyz
---
foo
bar
baz
<!-- endexcerpt -->
content
```

but this one doesn't:

```
---
abc: xyz
---
foo
bar
baz<!-- endexcerpt -->
content
```

In my content the excerpt delimiter is often considered as an _html comment_ and placed at the end of the last line of the excerpt. This PR allows the excerpt delimiter to be at the end of the last excerpt line.

## Code changes

Checking that the line `ends_with` the excerpt delimiter instead of checking that the line content _is_ the excerpt delimiter.