### PR TITLE
replace unmaintained yaml-rust with yaml-rust2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 serde = { version = "1.0.137", features = ["derive"] }
 json = { package = "serde_json", version = "1.0.81" }
 toml = { version = "0.5.9", optional = true }
-yaml = { package = "yaml-rust", version = "0.4.5", optional = true }
+yaml = { package = "yaml-rust2", version = "0.8.0", optional = true }
 
 [features]
 default = ["toml", "yaml"]


### PR DESCRIPTION
`yaml-rust` appears to be [unmaintained](https://github.com/rustsec/advisory-db/issues/1921) however, the community has published an actively maintained fork under the name of `yaml-rust2` ([package](https://crates.io/crates/yaml-rust2), [repo](https://github.com/Ethiraric/yaml-rust2)). It was forked from the latest commit of `yaml-rust` and is a drop-in replacement, as well as being improved by multiple developers (details of which are in the linked issue above).

RustSec advisory advising this course of action can be found here: [RUSTSEC-2024-0320](https://rustsec.org/advisories/RUSTSEC-2024-0320.html).